### PR TITLE
✨ モバイル向けサイドバーの実装

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 import type { Metadata, Viewport } from "next";
 import type { JSX } from "react";
 
-import { Navbar } from "@/components/navbar";
+import { LayoutWrapper } from "@/components/layout-wrapper";
 import { fontSans } from "@/config/fonts";
 import { siteConfig } from "@/config/site";
 import Metrics from "@/metrics";
@@ -49,8 +49,7 @@ export default function RootLayout({
       >
         <Providers themeProps={{ attribute: "class", defaultTheme: "dark" }}>
           <YouTubePlayerProvider>
-            <div className="relative flex flex-col h-screen">
-              <Navbar />
+            <LayoutWrapper>
               <main className="container mx-auto max-w-full md:px-6 flex-grow">
                 {children}
               </main>
@@ -65,7 +64,7 @@ export default function RootLayout({
                   <p className="text-primary">NextUI</p>
                 </Link>
               </footer>
-            </div>
+            </LayoutWrapper>
           </YouTubePlayerProvider>
         </Providers>
         <Metrics />

--- a/apps/web/components/layout-wrapper.tsx
+++ b/apps/web/components/layout-wrapper.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Navbar } from "@/components/navbar";
+import { Sidebar } from "@/components/sidebar";
+import { type JSX, useState } from "react";
+
+interface LayoutWrapperProps {
+  children: React.ReactNode;
+}
+
+export function LayoutWrapper({ children }: LayoutWrapperProps): JSX.Element {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  return (
+    <div className="relative flex flex-col h-screen">
+      <Navbar onSidebarOpen={() => setIsSidebarOpen(true)} />
+      <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
+      {children}
+    </div>
+  );
+}

--- a/apps/web/components/navbar.tsx
+++ b/apps/web/components/navbar.tsx
@@ -5,7 +5,9 @@ import { siteConfig } from "@/config/site";
 import { organizationMap } from "@/const/organizations";
 import { useYouTubePlayer } from "@/hooks/useYouTubePlayerContext";
 import type { Organization } from "@/lib/holodex";
+import { Bars3Icon } from "@heroicons/react/24/outline";
 import {
+  Button,
   Link,
   NavbarBrand,
   NavbarContent,
@@ -38,7 +40,11 @@ const getLeafSegmentName = (path: string): string => {
   return decodeURIComponent(path.split("/")[2]?.trim() || "");
 };
 
-export function Navbar(): JSX.Element {
+interface NavbarProps {
+  onSidebarOpen: () => void;
+}
+
+export function Navbar({ onSidebarOpen }: NavbarProps): JSX.Element {
   const router = useRouter();
   const pathName = usePathname();
   const segmentName = getSegmentName(pathName);
@@ -69,6 +75,18 @@ export function Navbar(): JSX.Element {
       position="sticky"
     >
       <NavbarContent className="basis-1/5 sm:basis-full" justify="start">
+        <NavbarItem className="lg:hidden">
+          <Button
+            isIconOnly
+            aria-label="Open menu"
+            className="min-w-unit-8 min-h-unit-8"
+            onClick={onSidebarOpen}
+            size="sm"
+            variant="light"
+          >
+            <Bars3Icon className="h-6 w-6" />
+          </Button>
+        </NavbarItem>
         <NavbarBrand as="li" className="gap-3 max-w-fit mr-4">
           <NextLink className="flex justify-start items-center gap-1" href="/">
             <Logo />

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import OrgSelector from "@/components/org-selector";
+import { organizationMap } from "@/const/organizations";
+import type { Organization } from "@/lib/holodex";
+import { Modal, ModalBody, ModalContent, ModalHeader } from "@heroui/react";
+import { usePathname, useRouter } from "next/navigation";
+import { type JSX, useEffect } from "react";
+
+const getLeafSegmentName = (path: string): string => {
+  if (path === "/") {
+    return "";
+  }
+  return decodeURIComponent(path.split("/")[2]?.trim() || "");
+};
+
+interface SidebarProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function Sidebar({ isOpen, onClose }: SidebarProps): JSX.Element {
+  const router = useRouter();
+  const pathName = usePathname();
+  const leafSegmentName = getLeafSegmentName(pathName);
+
+  // ブレークポイントの監視
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 768px)");
+    const handleResize = (e: MediaQueryListEvent) => {
+      if (e.matches && isOpen) {
+        onClose();
+      }
+    };
+
+    mediaQuery.addEventListener("change", handleResize);
+    return () => mediaQuery.removeEventListener("change", handleResize);
+  }, [isOpen, onClose]);
+
+  const onChangeOrganization = (organization: Organization) => {
+    onClose();
+    router.push(`/live-videos/${organization.id}`);
+  };
+
+  // モバイル用のモーダル表示
+  return (
+    <Modal
+      backdrop="blur"
+      className="md:hidden"
+      hideCloseButton
+      isOpen={isOpen}
+      motionProps={{
+        variants: {
+          enter: {
+            x: 0,
+            transition: {
+              duration: 0.3,
+              ease: "easeOut",
+            },
+          },
+          exit: {
+            x: "-100%",
+            transition: {
+              duration: 0.2,
+              ease: "easeIn",
+            },
+          },
+        },
+      }}
+      onClose={onClose}
+      placement="bottom-center"
+    >
+      <ModalContent className="h-full max-w-[280px]">
+        <ModalHeader className="flex flex-col gap-1">Menu</ModalHeader>
+        <ModalBody className="flex flex-col gap-6">
+          <div className="flex flex-col gap-4">
+            <OrgSelector
+              items={organizationMap}
+              selectedKey={leafSegmentName}
+              onChange={onChangeOrganization}
+            />
+          </div>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}


### PR DESCRIPTION
- アニメーション付きのサイドバーコンポーネントを追加
- レイアウトをクライアントコンポーネントに分離してサイドバーの状態管理を実装
- ハンバーガーメニューボタンの追加とサイドバーの開閉制御を実装
- レスポンシブ対応：lgブレークポイント以上で自動的に閉じる