### PR TITLE
Limit Chromatic deployments to pull requests and non-renovate branches

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,10 @@
 name: "Chromatic"
 
-on: push
+on:
+  pull_request:
+  push:
+    branches:
+      - "!renovate/*"
 
 jobs:
   chromatic:


### PR DESCRIPTION
This pull request limits Chromatic deployments to pull requests and branches that do not start with renovate/*.