### PR TITLE
fix(deps): update msw-storybook-addon to 2.0.7 to fix Chromatic CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cspell": "9.8.0",
     "dotenv": "17.4.2",
     "msw": "2.13.4",
-    "msw-storybook-addon": "2.0.6",
+    "msw-storybook-addon": "2.0.7",
     "tsconfig": "workspace:*",
     "turbo": "2.9.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 2.13.4
         version: 2.13.4(@types/node@24.12.2)(typescript@5.9.3)
       msw-storybook-addon:
-        specifier: 2.0.6
-        version: 2.0.6(msw@2.13.4(@types/node@24.12.2)(typescript@5.9.3))
+        specifier: 2.0.7
+        version: 2.0.7(msw@2.13.4(@types/node@24.12.2)(typescript@5.9.3))
       tsconfig:
         specifier: workspace:*
         version: link:packages/tsconfig
@@ -6040,8 +6040,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw-storybook-addon@2.0.6:
-    resolution: {integrity: sha512-ExCwDbcJoM2V3iQU+fZNp+axVfNc7DWMRh4lyTXebDO8IbpUNYKGFUrA8UqaeWiRGKVuS7+fU+KXEa9b0OP6uA==}
+  msw-storybook-addon@2.0.7:
+    resolution: {integrity: sha512-TGmlxXy2TsaB6QcClVKRxqvay5f93xoLguHOihRFQ+gIEIyiyvcoQjkEeuOe7Y9qvddzGB1LyFomzPo9/EpnuQ==}
     peerDependencies:
       msw: ^2.0.0
 
@@ -14669,7 +14669,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw-storybook-addon@2.0.6(msw@2.13.4(@types/node@24.12.2)(typescript@5.9.3)):
+  msw-storybook-addon@2.0.7(msw@2.13.4(@types/node@24.12.2)(typescript@5.9.3)):
     dependencies:
       is-node-process: 1.2.0
       msw: 2.13.4(@types/node@24.12.2)(typescript@5.9.3)


### PR DESCRIPTION
## 問題

MSW 2.13.x で \worker.context\ プロパティが削除されたため、\msw-storybook-addon@2.0.6\ の内部コードが \TypeError: Cannot set properties of undefined (setting 'activationPromise')\ でクラッシュし、全 PR の Chromatic CI が失敗していた。

## 修正

\msw-storybook-addon\ を 2.0.7 に更新。このバージョンで \worker.context\ への依存が除去された（[#184](https://github.com/mswjs/msw-storybook-addon/pull/184)）。

## 影響

この PR がマージされると、以下の PR の Chromatic CI が再実行で通るようになる:
- #1625, #1623, #1619, #1622, #1621 等の滞留 PR