### PR TITLE
test(nijiviewer): cover API Route Handlers (PR 2/5)

### DIFF
--- a/apps/nijiviewer/app/api/auth/callback/route.test.ts
+++ b/apps/nijiviewer/app/api/auth/callback/route.test.ts
@@ -1,0 +1,115 @@
+import { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { cookiesMock, createServerClientMock } = vi.hoisted(() => ({
+  cookiesMock: vi.fn(),
+  createServerClientMock: vi.fn(),
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: cookiesMock,
+}));
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: createServerClientMock,
+}));
+
+import { GET } from './route';
+
+const buildRequest = (params?: Record<string, string>): NextRequest => {
+  const url = new URL('http://localhost/api/auth/callback');
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      url.searchParams.set(k, v);
+    }
+  }
+  return new NextRequest(url);
+};
+
+describe('GET /api/auth/callback', () => {
+  beforeEach(() => {
+    createServerClientMock.mockReset();
+    cookiesMock.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('redirects to origin without exchanging when code is missing', async () => {
+    const res = await GET(buildRequest());
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe('http://localhost/');
+    expect(createServerClientMock).not.toHaveBeenCalled();
+    expect(cookiesMock).not.toHaveBeenCalled();
+  });
+
+  it('exchanges the code for a session and redirects to origin', async () => {
+    const cookieStore = {
+      getAll: vi.fn(() => [{ name: 'sb-access', value: 'v', options: {} }]),
+      set: vi.fn(),
+    };
+    cookiesMock.mockResolvedValue(cookieStore);
+    const exchange = vi.fn().mockResolvedValue({});
+    createServerClientMock.mockReturnValue({
+      auth: { exchangeCodeForSession: exchange },
+    });
+
+    const res = await GET(buildRequest({ code: 'abc' }));
+
+    expect(exchange).toHaveBeenCalledWith('abc');
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe('http://localhost/');
+  });
+
+  it('writes cookies via setAll and tolerates Server Component throws', async () => {
+    const cookieStore = {
+      getAll: vi.fn(() => []),
+      set: vi
+        .fn()
+        // First write succeeds, second throws to simulate Server Component restriction.
+        .mockImplementationOnce(() => undefined)
+        .mockImplementationOnce(() => {
+          throw new Error('cannot set cookies in Server Component');
+        }),
+    };
+    cookiesMock.mockResolvedValue(cookieStore);
+
+    const cookieAdapters: Array<{
+      getAll: () => unknown;
+      setAll: (
+        cookies: Array<{
+          name: string;
+          value: string;
+          options?: Record<string, unknown>;
+        }>,
+      ) => void;
+    }> = [];
+
+    createServerClientMock.mockImplementation((_url, _key, opts) => {
+      cookieAdapters.push(opts.cookies);
+      return {
+        auth: { exchangeCodeForSession: vi.fn().mockResolvedValue({}) },
+      };
+    });
+
+    await GET(buildRequest({ code: 'xyz' }));
+
+    expect(cookieAdapters).toHaveLength(1);
+    const adapter = cookieAdapters[0];
+
+    // Verify the getAll forwarder.
+    expect(adapter.getAll()).toEqual([]);
+    expect(cookieStore.getAll).toHaveBeenCalled();
+
+    // Calling setAll with two cookies — the second throws and should be swallowed.
+    expect(() =>
+      adapter.setAll([
+        { name: 'a', value: '1', options: { path: '/' } },
+        { name: 'b', value: '2', options: { path: '/' } },
+      ]),
+    ).not.toThrow();
+
+    expect(cookieStore.set).toHaveBeenCalledWith('a', '1', { path: '/' });
+    expect(cookieStore.set).toHaveBeenCalledWith('b', '2', { path: '/' });
+  });
+});

--- a/apps/nijiviewer/app/api/image-proxy/route.test.ts
+++ b/apps/nijiviewer/app/api/image-proxy/route.test.ts
@@ -14,6 +14,28 @@ const buildRequest = (params?: Record<string, string>): NextRequest => {
   return new NextRequest(url);
 };
 
+interface UpstreamCapture {
+  referer: string | null;
+}
+
+const arrangeUpstreamImage = (
+  url: string,
+  options: { contentType?: string; bytes?: Uint8Array } = {},
+): UpstreamCapture => {
+  const captured: UpstreamCapture = { referer: null };
+  const bytes = options.bytes ?? new Uint8Array([1]);
+  const contentType = options.contentType ?? 'image/png';
+  server.use(
+    http.get(url, ({ request }) => {
+      captured.referer = request.headers.get('Referer');
+      return HttpResponse.arrayBuffer(bytes.buffer, {
+        headers: { 'Content-Type': contentType },
+      });
+    }),
+  );
+  return captured;
+};
+
 describe('GET /api/image-proxy', () => {
   beforeEach(() => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -31,9 +53,7 @@ describe('GET /api/image-proxy', () => {
   });
 
   it('returns 400 for non-http(s) protocols', async () => {
-    const res = await GET(
-      buildRequest({ url: 'file:///etc/passwd' }),
-    );
+    const res = await GET(buildRequest({ url: 'file:///etc/passwd' }));
     expect(res.status).toBe(400);
     await expect(res.json()).resolves.toEqual({ error: 'Invalid protocol' });
   });
@@ -50,13 +70,7 @@ describe('GET /api/image-proxy', () => {
   it('proxies an image successfully and forwards Content-Type', async () => {
     const upstreamUrl = 'https://example.com/cat.png';
     const bytes = new Uint8Array([1, 2, 3, 4]);
-    server.use(
-      http.get(upstreamUrl, () =>
-        HttpResponse.arrayBuffer(bytes.buffer, {
-          headers: { 'Content-Type': 'image/png' },
-        }),
-      ),
-    );
+    arrangeUpstreamImage(upstreamUrl, { bytes });
 
     const res = await GET(buildRequest({ url: upstreamUrl }));
     expect(res.status).toBe(200);
@@ -67,15 +81,9 @@ describe('GET /api/image-proxy', () => {
     expect(new Uint8Array(buf)).toEqual(bytes);
   });
 
-  it('falls back to image/jpeg when upstream omits Content-Type', async () => {
+  it('passes through application/octet-stream as-is', async () => {
     const upstreamUrl = 'https://example.com/no-type.bin';
-    server.use(
-      http.get(upstreamUrl, () =>
-        HttpResponse.arrayBuffer(new Uint8Array([0]).buffer, {
-          headers: { 'Content-Type': 'application/octet-stream' },
-        }),
-      ),
-    );
+    arrangeUpstreamImage(upstreamUrl, { contentType: 'application/octet-stream' });
 
     const res = await GET(buildRequest({ url: upstreamUrl }));
     expect(res.status).toBe(200);
@@ -99,53 +107,24 @@ describe('GET /api/image-proxy', () => {
     });
   });
 
-  it('forwards Bilibili Referer for hdslb.com hostnames', async () => {
-    const upstreamUrl = 'https://i0.hdslb.com/cat.png';
-    let receivedReferer: string | null = null;
-    server.use(
-      http.get(upstreamUrl, ({ request }) => {
-        receivedReferer = request.headers.get('Referer');
-        return HttpResponse.arrayBuffer(new Uint8Array([1]).buffer, {
-          headers: { 'Content-Type': 'image/png' },
-        });
-      }),
-    );
+  it.each([
+    ['hdslb.com', 'https://i0.hdslb.com/cat.png', 'https://www.bilibili.com/'],
+    [
+      'bilibili.com',
+      'https://www.bilibili.com/cat.png',
+      'https://www.bilibili.com/',
+    ],
+    ['unrelated host', 'https://example.com/cat.png', null],
+  ])(
+    'sets Bilibili Referer only for Bilibili-family hostnames (%s)',
+    async (_label, upstreamUrl, expectedReferer) => {
+      const captured = arrangeUpstreamImage(upstreamUrl);
 
-    await GET(buildRequest({ url: upstreamUrl }));
-    expect(receivedReferer).toBe('https://www.bilibili.com/');
-  });
+      await GET(buildRequest({ url: upstreamUrl }));
 
-  it('forwards Bilibili Referer for bilibili.com hostnames', async () => {
-    const upstreamUrl = 'https://www.bilibili.com/cat.png';
-    let receivedReferer: string | null = null;
-    server.use(
-      http.get(upstreamUrl, ({ request }) => {
-        receivedReferer = request.headers.get('Referer');
-        return HttpResponse.arrayBuffer(new Uint8Array([1]).buffer, {
-          headers: { 'Content-Type': 'image/png' },
-        });
-      }),
-    );
-
-    await GET(buildRequest({ url: upstreamUrl }));
-    expect(receivedReferer).toBe('https://www.bilibili.com/');
-  });
-
-  it('does not forward Bilibili Referer for unrelated hostnames', async () => {
-    const upstreamUrl = 'https://example.com/cat.png';
-    let receivedReferer: string | null = null;
-    server.use(
-      http.get(upstreamUrl, ({ request }) => {
-        receivedReferer = request.headers.get('Referer');
-        return HttpResponse.arrayBuffer(new Uint8Array([1]).buffer, {
-          headers: { 'Content-Type': 'image/png' },
-        });
-      }),
-    );
-
-    await GET(buildRequest({ url: upstreamUrl }));
-    expect(receivedReferer).toBeNull();
-  });
+      expect(captured.referer).toBe(expectedReferer);
+    },
+  );
 
   it('returns the upstream status when fetch responds with a non-OK status', async () => {
     const upstreamUrl = 'https://example.com/missing.png';

--- a/apps/nijiviewer/app/api/image-proxy/route.test.ts
+++ b/apps/nijiviewer/app/api/image-proxy/route.test.ts
@@ -1,0 +1,176 @@
+import { http, HttpResponse } from 'msw';
+import { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { server } from '@/test/msw/server';
+import { GET } from './route';
+
+const buildRequest = (params?: Record<string, string>): NextRequest => {
+  const url = new URL('http://localhost/api/image-proxy');
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      url.searchParams.set(k, v);
+    }
+  }
+  return new NextRequest(url);
+};
+
+describe('GET /api/image-proxy', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns 400 when url param is missing', async () => {
+    const res = await GET(buildRequest());
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: 'URL parameter is required',
+    });
+  });
+
+  it('returns 400 for non-http(s) protocols', async () => {
+    const res = await GET(
+      buildRequest({ url: 'file:///etc/passwd' }),
+    );
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'Invalid protocol' });
+  });
+
+  it('returns 500 when the URL string is malformed', async () => {
+    const res = await GET(buildRequest({ url: 'not a url' }));
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({
+      error: 'Internal server error',
+    });
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('proxies an image successfully and forwards Content-Type', async () => {
+    const upstreamUrl = 'https://example.com/cat.png';
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    server.use(
+      http.get(upstreamUrl, () =>
+        HttpResponse.arrayBuffer(bytes.buffer, {
+          headers: { 'Content-Type': 'image/png' },
+        }),
+      ),
+    );
+
+    const res = await GET(buildRequest({ url: upstreamUrl }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('image/png');
+    expect(res.headers.get('Cache-Control')).toContain('max-age=3600');
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    const buf = await res.arrayBuffer();
+    expect(new Uint8Array(buf)).toEqual(bytes);
+  });
+
+  it('falls back to image/jpeg when upstream omits Content-Type', async () => {
+    const upstreamUrl = 'https://example.com/no-type.bin';
+    server.use(
+      http.get(upstreamUrl, () =>
+        HttpResponse.arrayBuffer(new Uint8Array([0]).buffer, {
+          headers: { 'Content-Type': 'application/octet-stream' },
+        }),
+      ),
+    );
+
+    const res = await GET(buildRequest({ url: upstreamUrl }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/octet-stream');
+  });
+
+  it('rejects responses whose Content-Type is not an image', async () => {
+    const upstreamUrl = 'https://example.com/page.html';
+    server.use(
+      http.get(upstreamUrl, () =>
+        HttpResponse.text('<html />', {
+          headers: { 'Content-Type': 'text/html' },
+        }),
+      ),
+    );
+
+    const res = await GET(buildRequest({ url: upstreamUrl }));
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: 'URL did not return an image',
+    });
+  });
+
+  it('forwards Bilibili Referer for hdslb.com hostnames', async () => {
+    const upstreamUrl = 'https://i0.hdslb.com/cat.png';
+    let receivedReferer: string | null = null;
+    server.use(
+      http.get(upstreamUrl, ({ request }) => {
+        receivedReferer = request.headers.get('Referer');
+        return HttpResponse.arrayBuffer(new Uint8Array([1]).buffer, {
+          headers: { 'Content-Type': 'image/png' },
+        });
+      }),
+    );
+
+    await GET(buildRequest({ url: upstreamUrl }));
+    expect(receivedReferer).toBe('https://www.bilibili.com/');
+  });
+
+  it('forwards Bilibili Referer for bilibili.com hostnames', async () => {
+    const upstreamUrl = 'https://www.bilibili.com/cat.png';
+    let receivedReferer: string | null = null;
+    server.use(
+      http.get(upstreamUrl, ({ request }) => {
+        receivedReferer = request.headers.get('Referer');
+        return HttpResponse.arrayBuffer(new Uint8Array([1]).buffer, {
+          headers: { 'Content-Type': 'image/png' },
+        });
+      }),
+    );
+
+    await GET(buildRequest({ url: upstreamUrl }));
+    expect(receivedReferer).toBe('https://www.bilibili.com/');
+  });
+
+  it('does not forward Bilibili Referer for unrelated hostnames', async () => {
+    const upstreamUrl = 'https://example.com/cat.png';
+    let receivedReferer: string | null = null;
+    server.use(
+      http.get(upstreamUrl, ({ request }) => {
+        receivedReferer = request.headers.get('Referer');
+        return HttpResponse.arrayBuffer(new Uint8Array([1]).buffer, {
+          headers: { 'Content-Type': 'image/png' },
+        });
+      }),
+    );
+
+    await GET(buildRequest({ url: upstreamUrl }));
+    expect(receivedReferer).toBeNull();
+  });
+
+  it('returns the upstream status when fetch responds with a non-OK status', async () => {
+    const upstreamUrl = 'https://example.com/missing.png';
+    server.use(
+      http.get(upstreamUrl, () =>
+        HttpResponse.text('not found', { status: 404 }),
+      ),
+    );
+
+    const res = await GET(buildRequest({ url: upstreamUrl }));
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({
+      error: 'Failed to fetch image',
+    });
+  });
+
+  it('returns 500 when the upstream fetch fails', async () => {
+    const upstreamUrl = 'https://example.com/error.png';
+    server.use(http.get(upstreamUrl, () => HttpResponse.error()));
+
+    const res = await GET(buildRequest({ url: upstreamUrl }));
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({
+      error: 'Internal server error',
+    });
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/apps/nijiviewer/app/api/videos/[type]/route.test.ts
+++ b/apps/nijiviewer/app/api/videos/[type]/route.test.ts
@@ -1,0 +1,164 @@
+import { http, HttpResponse } from 'msw';
+import { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockStreamVideo } from '@/test/fixtures/holodex';
+import { HOLODEX_BASE } from '@/test/msw/factories';
+import { server } from '@/test/msw/server';
+import { GET } from './route';
+
+type RouteContext = { params: Promise<{ type: string }> };
+
+const buildRequest = (params?: Record<string, string>): NextRequest => {
+  const url = new URL('http://localhost/api/videos/test');
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      url.searchParams.set(k, v);
+    }
+  }
+  return new NextRequest(url);
+};
+
+const ctx = (type: string): RouteContext => ({
+  params: Promise.resolve({ type }),
+});
+
+describe('GET /api/videos/[type]', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns 400 when channel_id is missing', async () => {
+    const res = await GET(buildRequest(), ctx('past'));
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: 'missing parameters',
+    });
+  });
+
+  it('returns 400 when type does not match a known route', async () => {
+    const res = await GET(
+      buildRequest({ channel_id: 'C' }),
+      ctx('upcoming'),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('proxies past videos for the channel', async () => {
+    const video = mockStreamVideo({ id: 'p1' });
+    let receivedUrl: URL | undefined;
+    server.use(
+      http.get(`${HOLODEX_BASE}/channels/:channelId/videos`, ({ request }) => {
+        receivedUrl = new URL(request.url);
+        return HttpResponse.json([video]);
+      }),
+    );
+
+    const res = await GET(
+      buildRequest({ channel_id: 'C-1', limit: '10' }),
+      ctx('past'),
+    );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual([video]);
+    expect(receivedUrl?.pathname).toBe('/api/v2/channels/C-1/videos');
+    expect(receivedUrl?.searchParams.get('lang')).toBe('en,ja');
+    expect(receivedUrl?.searchParams.get('type')).toBe('stream,placeholder');
+    expect(receivedUrl?.searchParams.get('include')).toBe('clips,live_info');
+    expect(receivedUrl?.searchParams.get('limit')).toBe('10');
+  });
+
+  it('proxies clips with status=past', async () => {
+    let receivedUrl: URL | undefined;
+    server.use(
+      http.get(`${HOLODEX_BASE}/channels/:channelId/clips`, ({ request }) => {
+        receivedUrl = new URL(request.url);
+        return HttpResponse.json([]);
+      }),
+    );
+
+    const res = await GET(
+      buildRequest({ channel_id: 'C-2' }),
+      ctx('clips'),
+    );
+    expect(res.status).toBe(200);
+    expect(receivedUrl?.pathname).toBe('/api/v2/channels/C-2/clips');
+    expect(receivedUrl?.searchParams.get('status')).toBe('past');
+  });
+
+  it('proxies collabs with status=past', async () => {
+    let receivedUrl: URL | undefined;
+    server.use(
+      http.get(`${HOLODEX_BASE}/channels/:channelId/collabs`, ({ request }) => {
+        receivedUrl = new URL(request.url);
+        return HttpResponse.json([]);
+      }),
+    );
+
+    const res = await GET(
+      buildRequest({ channel_id: 'C-3' }),
+      ctx('collabs'),
+    );
+    expect(res.status).toBe(200);
+    expect(receivedUrl?.pathname).toBe('/api/v2/channels/C-3/collabs');
+    expect(receivedUrl?.searchParams.get('status')).toBe('past');
+  });
+
+  it('returns 500 when the upstream fetch fails', async () => {
+    server.use(
+      http.get(`${HOLODEX_BASE}/channels/:channelId/videos`, () =>
+        HttpResponse.error(),
+      ),
+    );
+
+    const res = await GET(
+      buildRequest({ channel_id: 'C' }),
+      ctx('past'),
+    );
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({
+      error: 'Failed to fetch from Holodex API',
+    });
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('returns 500 when the upstream returns invalid JSON', async () => {
+    server.use(
+      http.get(`${HOLODEX_BASE}/channels/:channelId/videos`, () =>
+        HttpResponse.text('not-json', { status: 200 }),
+      ),
+    );
+
+    const res = await GET(
+      buildRequest({ channel_id: 'C' }),
+      ctx('past'),
+    );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Failed to parse Holodex API response');
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('returns 500 from the catch block when fetch throws synchronously', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(() => {
+        throw new Error('sync boom');
+      });
+
+    const res = await GET(
+      buildRequest({ channel_id: 'C' }),
+      ctx('past'),
+    );
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({
+      error: 'Internal server error',
+    });
+    expect(console.error).toHaveBeenCalledWith(
+      'Unexpected error:',
+      expect.any(Error),
+    );
+    fetchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Step 2/5 of the staged effort to take nijiviewer to 100% coverage. Brings the three Route Handlers under \`app/api/\` to **100% line / statement / function** coverage; branches all clear the **90%** bar.

| File | L | S | F | B |
|---|---|---|---|---|
| \`app/api/auth/callback/route.ts\` | 100% | 100% | 100% | 100% |
| \`app/api/image-proxy/route.ts\` | 100% | 100% | 100% | 90% |
| \`app/api/videos/[type]/route.ts\` | 100% | 100% | 100% | 92.85% |

Test count: **126 → 148** (+22 across three new files).

## Notes

- Auth callback's cookie adapter (\`getAll\` / \`setAll\`) is exercised by capturing the adapter that the route passes to \`createServerClient\`, then asserting forwarder behaviour and the swallowed Server-Component write throw.
- Image proxy's Bilibili Referer logic is verified for both \`hdslb.com\` and \`bilibili.com\` and the negative case for unrelated domains.
- The outer \`try/catch\` of \`videos/[type]/route.ts\` is otherwise unreachable through normal error paths because \`fromPromise\` swallows fetch and JSON failures into \`Result\`. To exercise it, one test stubs \`globalThis.fetch\` to throw synchronously — that's the only path that bypasses \`fromPromise\`'s wrap.

## Test plan

- [x] \`pnpm --filter @oichan/nijiviewer exec vitest run --project unit app/api\` — all 22 tests pass
- [x] \`pnpm --filter @oichan/nijiviewer test:coverage\` — verified the three files at L/S/F = 100, B ≥ 90
- [x] \`pnpm --filter @oichan/nijiviewer build\` — TS + Next build succeed
- [x] \`pnpm lint\` — Biome clean
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)