### PR TITLE
test(nijiviewer): cover Server Components and app/ pages (PR 3/5)

### DIFF
--- a/apps/nijiviewer/app/actions.test.ts
+++ b/apps/nijiviewer/app/actions.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockChannel, mockStreamVideo } from '@/test/fixtures/holodex';
+
+const { fetchChannelsMock, fetchUserLiveVideosMock } = vi.hoisted(() => ({
+  fetchChannelsMock: vi.fn(),
+  fetchUserLiveVideosMock: vi.fn(),
+}));
+
+vi.mock('@/lib/data', () => ({
+  fetchChannels: fetchChannelsMock,
+  fetchUserLiveVideos: fetchUserLiveVideosMock,
+}));
+
+import { getChannelsAction, getFavoritesLiveVideosAction } from './actions';
+
+describe('app/actions', () => {
+  beforeEach(() => {
+    fetchChannelsMock.mockReset();
+    fetchUserLiveVideosMock.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getChannelsAction', () => {
+    it('returns [] for empty input without calling fetchChannels', async () => {
+      await expect(getChannelsAction([])).resolves.toEqual([]);
+      expect(fetchChannelsMock).not.toHaveBeenCalled();
+    });
+
+    it('returns [] when ids is null/undefined-like', async () => {
+      await expect(
+        getChannelsAction(undefined as unknown as string[]),
+      ).resolves.toEqual([]);
+      expect(fetchChannelsMock).not.toHaveBeenCalled();
+    });
+
+    it('forwards non-empty ids to fetchChannels', async () => {
+      const channel = mockChannel({ id: 'c-1' });
+      fetchChannelsMock.mockResolvedValue([channel]);
+
+      await expect(getChannelsAction(['c-1'])).resolves.toEqual([channel]);
+      expect(fetchChannelsMock).toHaveBeenCalledWith(['c-1']);
+    });
+  });
+
+  describe('getFavoritesLiveVideosAction', () => {
+    it('returns [] for empty input without calling fetchUserLiveVideos', async () => {
+      await expect(getFavoritesLiveVideosAction([])).resolves.toEqual([]);
+      expect(fetchUserLiveVideosMock).not.toHaveBeenCalled();
+    });
+
+    it('returns [] when ids is null/undefined-like', async () => {
+      await expect(
+        getFavoritesLiveVideosAction(undefined as unknown as string[]),
+      ).resolves.toEqual([]);
+      expect(fetchUserLiveVideosMock).not.toHaveBeenCalled();
+    });
+
+    it('forwards non-empty ids to fetchUserLiveVideos', async () => {
+      const video = mockStreamVideo({ id: 'v-1' });
+      fetchUserLiveVideosMock.mockResolvedValue([video]);
+
+      await expect(getFavoritesLiveVideosAction(['c-1'])).resolves.toEqual([
+        video,
+      ]);
+      expect(fetchUserLiveVideosMock).toHaveBeenCalledWith(['c-1']);
+    });
+  });
+});

--- a/apps/nijiviewer/app/error.test.tsx
+++ b/apps/nijiviewer/app/error.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ErrorPage from './error';
+
+describe('Error page', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the fallback UI and logs the error on mount', () => {
+    const error = new Error('boom');
+    render(<ErrorPage error={error} reset={vi.fn()} />);
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Something went wrong!' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+    expect(console.error).toHaveBeenCalledWith(error);
+  });
+
+  it('invokes reset when the Try again button is clicked', () => {
+    const reset = vi.fn();
+    render(<ErrorPage error={new Error('boom')} reset={reset} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/nijiviewer/app/favorites/edit/page.test.tsx
+++ b/apps/nijiviewer/app/favorites/edit/page.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { mockUser } from '@/test/fixtures/auth';
+import { mockFavoriteLiver } from '@/test/fixtures/favorites';
+import { mockChannel } from '@/test/fixtures/holodex';
+import {
+  stubAuth,
+  stubFavorites,
+  wrapWithHeroUI,
+} from '@/test/helpers/auth-favorites-mocks';
+
+const {
+  useAuthMock,
+  useFavoriteLiversListMock,
+  getChannelsActionMock,
+  searchResultListMock,
+  scrollToTopMock,
+} = vi.hoisted(() => ({
+  useAuthMock: vi.fn(),
+  useFavoriteLiversListMock: vi.fn(),
+  getChannelsActionMock: vi.fn(),
+  searchResultListMock: vi.fn(() => null),
+  scrollToTopMock: vi.fn(() => null),
+}));
+
+vi.mock('@/context/auth-context', () => ({ useAuth: useAuthMock }));
+vi.mock('@/hooks/use-favorites', () => ({
+  useFavoriteLiversList: useFavoriteLiversListMock,
+}));
+vi.mock('@/app/actions', () => ({
+  getChannelsAction: getChannelsActionMock,
+}));
+vi.mock('@/components/search-result', () => ({
+  SearchResultList: searchResultListMock,
+}));
+vi.mock('@/components/scroll-to-top-button', () => ({
+  default: scrollToTopMock,
+}));
+
+import FavoritesEditPage from './page';
+
+describe('FavoritesEditPage', () => {
+  beforeEach(() => {
+    useAuthMock.mockReset();
+    useFavoriteLiversListMock.mockReset();
+    getChannelsActionMock.mockReset();
+    searchResultListMock.mockClear();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders only the spinner while auth is loading', () => {
+    stubAuth(useAuthMock, { isLoading: true });
+    stubFavorites(useFavoriteLiversListMock);
+
+    render(wrapWithHeroUI(<FavoritesEditPage />));
+    expect(
+      screen.queryByText('ログインしてお気に入り機能を利用しましょう。'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Manage Favorite Livers' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders only the spinner while favorites are loading', () => {
+    stubAuth(useAuthMock);
+    stubFavorites(useFavoriteLiversListMock, { isLoading: true });
+
+    render(wrapWithHeroUI(<FavoritesEditPage />));
+    expect(
+      screen.queryByText('ログインしてお気に入り機能を利用しましょう。'),
+    ).not.toBeInTheDocument();
+    expect(searchResultListMock).not.toHaveBeenCalled();
+  });
+
+  it('shows the sign-in prompt for unauthenticated users', async () => {
+    stubAuth(useAuthMock, { user: null });
+    stubFavorites(useFavoriteLiversListMock);
+
+    render(wrapWithHeroUI(<FavoritesEditPage />));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('ログインしてお気に入り機能を利用しましょう。'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows the empty message when user has no favorites', async () => {
+    const user = mockUser();
+    stubAuth(useAuthMock, { user });
+    stubFavorites(useFavoriteLiversListMock, { favorites: [] });
+
+    render(wrapWithHeroUI(<FavoritesEditPage />));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('お気に入りのライバーがいません。'),
+      ).toBeInTheDocument();
+    });
+    expect(getChannelsActionMock).not.toHaveBeenCalled();
+  });
+
+  it('renders SearchResultList with fetched channels when favorites exist', async () => {
+    const user = mockUser();
+    const fav = mockFavoriteLiver({ liver_id: 'C-1' });
+    const channel = mockChannel({ id: 'C-1' });
+    stubAuth(useAuthMock, { user });
+    stubFavorites(useFavoriteLiversListMock, { favorites: [fav] });
+    getChannelsActionMock.mockResolvedValue([channel]);
+
+    render(wrapWithHeroUI(<FavoritesEditPage />));
+
+    await waitFor(() => {
+      expect(getChannelsActionMock).toHaveBeenCalledWith(['C-1']);
+    });
+    await waitFor(() => {
+      expect(searchResultListMock).toHaveBeenCalled();
+    });
+    expect(searchResultListMock.mock.calls.at(-1)?.[0]).toEqual({
+      channels: [channel],
+    });
+  });
+
+  it('logs an error when getChannelsAction rejects', async () => {
+    const user = mockUser();
+    const fav = mockFavoriteLiver({ liver_id: 'C-1' });
+    stubAuth(useAuthMock, { user });
+    stubFavorites(useFavoriteLiversListMock, { favorites: [fav] });
+    const err = new Error('boom');
+    getChannelsActionMock.mockRejectedValue(err);
+
+    render(wrapWithHeroUI(<FavoritesEditPage />));
+
+    await waitFor(() => {
+      expect(console.error).toHaveBeenCalledWith(err);
+    });
+  });
+});

--- a/apps/nijiviewer/app/favorites/page.test.tsx
+++ b/apps/nijiviewer/app/favorites/page.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { mockUser } from '@/test/fixtures/auth';
+import { mockFavoriteLiver } from '@/test/fixtures/favorites';
+import { mockStreamVideo } from '@/test/fixtures/holodex';
+import {
+  stubAuth,
+  stubFavorites,
+  wrapWithHeroUI,
+} from '@/test/helpers/auth-favorites-mocks';
+
+const {
+  useAuthMock,
+  useFavoriteLiversListMock,
+  getFavoritesLiveVideosActionMock,
+  videosMock,
+  scrollToTopMock,
+} = vi.hoisted(() => ({
+  useAuthMock: vi.fn(),
+  useFavoriteLiversListMock: vi.fn(),
+  getFavoritesLiveVideosActionMock: vi.fn(),
+  videosMock: vi.fn(() => null),
+  scrollToTopMock: vi.fn(() => null),
+}));
+
+vi.mock('@/context/auth-context', () => ({ useAuth: useAuthMock }));
+vi.mock('@/hooks/use-favorites', () => ({
+  useFavoriteLiversList: useFavoriteLiversListMock,
+}));
+vi.mock('@/app/actions', () => ({
+  getFavoritesLiveVideosAction: getFavoritesLiveVideosActionMock,
+}));
+vi.mock('@/components/videos', () => ({ default: videosMock }));
+vi.mock('@/components/scroll-to-top-button', () => ({
+  default: scrollToTopMock,
+}));
+
+import FavoritesPage from './page';
+
+describe('FavoritesPage', () => {
+  beforeEach(() => {
+    useAuthMock.mockReset();
+    useFavoriteLiversListMock.mockReset();
+    getFavoritesLiveVideosActionMock.mockReset();
+    videosMock.mockClear();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows the spinner (and nothing else) while auth is loading', () => {
+    stubAuth(useAuthMock, { isLoading: true });
+    stubFavorites(useFavoriteLiversListMock);
+
+    render(wrapWithHeroUI(<FavoritesPage />));
+    expect(
+      screen.queryByText('ログインしてお気に入り機能を利用しましょう。'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Favorite Live Videos' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the spinner (and nothing else) while favorites are loading', () => {
+    stubAuth(useAuthMock);
+    stubFavorites(useFavoriteLiversListMock, { isLoading: true });
+
+    render(wrapWithHeroUI(<FavoritesPage />));
+    expect(
+      screen.queryByText('ログインしてお気に入り機能を利用しましょう。'),
+    ).not.toBeInTheDocument();
+    expect(videosMock).not.toHaveBeenCalled();
+  });
+
+  it('shows the sign-in prompt when user is null', async () => {
+    stubAuth(useAuthMock, { user: null });
+    stubFavorites(useFavoriteLiversListMock);
+
+    render(wrapWithHeroUI(<FavoritesPage />));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('ログインしてお気に入り機能を利用しましょう。'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows the empty state when the user has no favorites', async () => {
+    const user = mockUser();
+    stubAuth(useAuthMock, { user });
+    stubFavorites(useFavoriteLiversListMock, { favorites: [] });
+
+    render(wrapWithHeroUI(<FavoritesPage />));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/お気に入りのライバーがいません/),
+      ).toBeInTheDocument();
+    });
+    expect(getFavoritesLiveVideosActionMock).not.toHaveBeenCalled();
+  });
+
+  it('renders Videos with the action result when favorites exist', async () => {
+    const user = mockUser();
+    const fav = mockFavoriteLiver({ liver_id: 'liver-1' });
+    const video = mockStreamVideo({ id: 'v-1' });
+    stubAuth(useAuthMock, { user });
+    stubFavorites(useFavoriteLiversListMock, { favorites: [fav] });
+    getFavoritesLiveVideosActionMock.mockResolvedValue([video]);
+
+    render(wrapWithHeroUI(<FavoritesPage />));
+
+    await waitFor(() => {
+      expect(getFavoritesLiveVideosActionMock).toHaveBeenCalledWith(['liver-1']);
+    });
+    await waitFor(() => {
+      expect(videosMock).toHaveBeenCalled();
+    });
+    expect(videosMock.mock.calls.at(-1)?.[0]).toEqual({ videos: [video] });
+  });
+
+  it('logs the error and stops the spinner when the action fails', async () => {
+    const user = mockUser();
+    const fav = mockFavoriteLiver({ liver_id: 'liver-1' });
+    stubAuth(useAuthMock, { user });
+    stubFavorites(useFavoriteLiversListMock, { favorites: [fav] });
+    const err = new Error('boom');
+    getFavoritesLiveVideosActionMock.mockRejectedValue(err);
+
+    render(wrapWithHeroUI(<FavoritesPage />));
+
+    await waitFor(() => {
+      expect(console.error).toHaveBeenCalledWith(err);
+    });
+  });
+});

--- a/apps/nijiviewer/app/layout.test.tsx
+++ b/apps/nijiviewer/app/layout.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/font/google', () => ({
+  Inter: () => ({ variable: '--font-sans', className: 'font-sans' }),
+  Fira_Code: () => ({ variable: '--font-mono', className: 'font-mono' }),
+}));
+
+vi.mock('@/styles/globals.css', () => ({}));
+
+vi.mock('./providers', () => ({
+  Providers: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="providers">{children}</div>
+  ),
+}));
+
+vi.mock('@/context/preferences-context', () => ({
+  PreferencesProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="preferences">{children}</div>
+  ),
+  usePreferences: () => ({}),
+}));
+
+vi.mock('@/context/sidebar-context', () => ({
+  SidebarProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sidebar">{children}</div>
+  ),
+  useSidebar: () => ({}),
+}));
+
+vi.mock('@/hooks/useYouTubePlayerContext', () => ({
+  YouTubePlayerProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="youtube-provider">{children}</div>
+  ),
+  useYouTubePlayer: () => ({}),
+}));
+
+vi.mock('@/components/navbar', () => ({
+  Navbar: () => <nav data-testid="navbar">navbar</nav>,
+}));
+
+vi.mock('@/components/layout-component', () => ({
+  LayoutComponent: ({ children }: { children: React.ReactNode }) => (
+    <main data-testid="layout-component">{children}</main>
+  ),
+}));
+
+vi.mock('@/components/mobile-bottom-nav', () => ({
+  MobileBottomNav: () => <nav data-testid="mobile-bottom-nav" />,
+}));
+
+vi.mock('@/components/in-app-youtube-player', () => ({
+  default: () => <div data-testid="in-app-yt" />,
+}));
+
+vi.mock('@/metrics', () => ({
+  default: () => <div data-testid="metrics" />,
+}));
+
+import RootLayout, { metadata, viewport } from './layout';
+
+describe('RootLayout', () => {
+  it('renders children inside the provider stack', () => {
+    render(
+      <RootLayout>
+        <span data-testid="page">page-body</span>
+      </RootLayout>,
+    );
+
+    expect(screen.getByTestId('providers')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument();
+    expect(screen.getByTestId('preferences')).toBeInTheDocument();
+    expect(screen.getByTestId('youtube-provider')).toBeInTheDocument();
+    expect(screen.getByTestId('navbar')).toBeInTheDocument();
+    expect(screen.getByTestId('layout-component')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-bottom-nav')).toBeInTheDocument();
+    expect(screen.getByTestId('in-app-yt')).toBeInTheDocument();
+    expect(screen.getByTestId('metrics')).toBeInTheDocument();
+    expect(screen.getByTestId('page')).toHaveTextContent('page-body');
+  });
+
+  it('exposes metadata and viewport configuration', () => {
+    expect(metadata.title).toBeDefined();
+    expect(metadata.icons).toEqual({ icon: '/favicon.ico' });
+    expect(Array.isArray(viewport.themeColor)).toBe(true);
+  });
+});

--- a/apps/nijiviewer/app/live-videos/[organizationName]/page.test.tsx
+++ b/apps/nijiviewer/app/live-videos/[organizationName]/page.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockStreamVideo } from '@/test/fixtures/holodex';
+
+const { fetchLiveVideosMock, videosMock } = vi.hoisted(() => ({
+  fetchLiveVideosMock: vi.fn(),
+  videosMock: vi.fn(() => null),
+}));
+
+vi.mock('@/lib/data', () => ({
+  fetchLiveVideos: fetchLiveVideosMock,
+}));
+
+vi.mock('@/components/videos', () => ({
+  default: videosMock,
+}));
+
+import LiveVideosPage from './page';
+
+const ctx = (organizationName: string) => ({
+  params: Promise.resolve({ organizationName }),
+});
+
+describe('LiveVideos [organizationName] page', () => {
+  beforeEach(() => {
+    fetchLiveVideosMock.mockReset();
+    videosMock.mockClear();
+  });
+
+  it('renders Videos with fetched data for a valid organization', async () => {
+    const video = mockStreamVideo({ id: 'v1' });
+    fetchLiveVideosMock.mockResolvedValue([video]);
+
+    const tree = await LiveVideosPage(ctx('Nijisanji'));
+    render(tree);
+
+    expect(fetchLiveVideosMock).toHaveBeenCalledWith('Nijisanji');
+    expect(videosMock).toHaveBeenCalled();
+    expect(videosMock.mock.calls[0][0]).toEqual({ videos: [video] });
+  });
+
+  it('returns "Request Error" when organizationName is unknown', async () => {
+    const tree = await LiveVideosPage(ctx('Unknown'));
+    render(tree);
+
+    expect(screen.getByText('Request Error')).toBeInTheDocument();
+    expect(fetchLiveVideosMock).not.toHaveBeenCalled();
+  });
+
+  it('returns "Request Error" when organizationName is empty', async () => {
+    const tree = await LiveVideosPage(ctx(''));
+    render(tree);
+
+    expect(screen.getByText('Request Error')).toBeInTheDocument();
+    expect(fetchLiveVideosMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/nijiviewer/app/live-videos/layout.test.tsx
+++ b/apps/nijiviewer/app/live-videos/layout.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import LiveVideosLayout from './layout';
+
+describe('LiveVideosLayout', () => {
+  it('renders the children inside the section wrapper', () => {
+    render(
+      <LiveVideosLayout>
+        <p data-testid="child">child</p>
+      </LiveVideosLayout>,
+    );
+
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+});

--- a/apps/nijiviewer/app/liver-search/layout.test.tsx
+++ b/apps/nijiviewer/app/liver-search/layout.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import LiverSearchLayout from './layout';
+
+describe('LiverSearchLayout', () => {
+  it('renders the children inside the section wrapper', () => {
+    render(
+      <LiverSearchLayout>
+        <p data-testid="child">child</p>
+      </LiverSearchLayout>,
+    );
+
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+});

--- a/apps/nijiviewer/app/liver-search/page.test.tsx
+++ b/apps/nijiviewer/app/liver-search/page.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockChannel } from '@/test/fixtures/holodex';
+
+const { searchChannelsMock, searchResultListMock } = vi.hoisted(() => ({
+  searchChannelsMock: vi.fn(),
+  searchResultListMock: vi.fn(() => null),
+}));
+
+vi.mock('@/lib/data', () => ({
+  searchChannels: searchChannelsMock,
+}));
+
+vi.mock('@/components/search-result', () => ({
+  SearchResultList: searchResultListMock,
+}));
+
+import LiverSearchPage from './page';
+
+const ctx = (q?: string) => ({
+  searchParams: Promise.resolve(q === undefined ? {} : { q }),
+});
+
+describe('LiverSearchPage', () => {
+  beforeEach(() => {
+    searchChannelsMock.mockReset();
+    searchResultListMock.mockClear();
+  });
+
+  it('renders only the title when q is empty', async () => {
+    searchChannelsMock.mockResolvedValue([]);
+
+    const tree = await LiverSearchPage(ctx() as Parameters<typeof LiverSearchPage>[0]);
+    render(tree);
+
+    expect(screen.getByRole('heading', { name: 'Liver List' })).toBeInTheDocument();
+    expect(screen.queryByText(/Search Results for/)).not.toBeInTheDocument();
+    expect(searchResultListMock).not.toHaveBeenCalled();
+  });
+
+  it('renders "No livers found" when search returns empty', async () => {
+    searchChannelsMock.mockResolvedValue([]);
+
+    const tree = await LiverSearchPage(ctx('foo'));
+    render(tree);
+
+    expect(searchChannelsMock).toHaveBeenCalledWith('foo');
+    expect(screen.getByText('Search Results for "foo"')).toBeInTheDocument();
+    expect(screen.getByText('No livers found')).toBeInTheDocument();
+    expect(searchResultListMock).not.toHaveBeenCalled();
+  });
+
+  it('renders SearchResultList when channels are returned', async () => {
+    const channel = mockChannel();
+    searchChannelsMock.mockResolvedValue([channel]);
+
+    const tree = await LiverSearchPage(ctx('foo'));
+    render(tree);
+
+    expect(searchResultListMock).toHaveBeenCalled();
+    expect(searchResultListMock.mock.calls[0][0]).toEqual({ channels: [channel] });
+  });
+});

--- a/apps/nijiviewer/app/liver/[channelId]/page.test.tsx
+++ b/apps/nijiviewer/app/liver/[channelId]/page.test.tsx
@@ -1,0 +1,79 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockChannel } from '@/test/fixtures/holodex';
+
+const { fetchChannelInfoMock, notFoundMock, liverProfileMock, videoTabsMock } =
+  vi.hoisted(() => ({
+    fetchChannelInfoMock: vi.fn(),
+    notFoundMock: vi.fn(() => {
+      throw new Error('NEXT_NOT_FOUND');
+    }),
+    liverProfileMock: vi.fn(() => null),
+    videoTabsMock: vi.fn(() => null),
+  }));
+
+vi.mock('@/lib/data', () => ({
+  fetchChannelInfo: fetchChannelInfoMock,
+}));
+
+vi.mock('next/navigation', async () => {
+  const actual = await vi.importActual<typeof import('next/navigation')>(
+    'next/navigation',
+  );
+  return {
+    ...actual,
+    notFound: notFoundMock,
+  };
+});
+
+vi.mock('@/components/liver-profile', () => ({
+  default: liverProfileMock,
+}));
+
+vi.mock('@/components/video-tabs', () => ({
+  default: videoTabsMock,
+}));
+
+import LiverPage from './page';
+
+const ctx = (channelId: string) => ({
+  params: Promise.resolve({ channelId }),
+});
+
+describe('LiverPage', () => {
+  beforeEach(() => {
+    fetchChannelInfoMock.mockReset();
+    notFoundMock.mockClear();
+    liverProfileMock.mockClear();
+    videoTabsMock.mockClear();
+  });
+
+  it('renders profile and tabs when the channel is found', async () => {
+    const channel = mockChannel({ id: 'C-1' });
+    fetchChannelInfoMock.mockResolvedValue(channel);
+
+    const tree = await LiverPage(ctx('C-1'));
+    render(tree);
+
+    expect(fetchChannelInfoMock).toHaveBeenCalledWith('C-1');
+    expect(liverProfileMock).toHaveBeenCalled();
+    expect(liverProfileMock.mock.calls[0][0]).toEqual({ channel });
+    expect(videoTabsMock).toHaveBeenCalled();
+    expect(videoTabsMock.mock.calls[0][0]).toEqual({ channelId: 'C-1' });
+    expect(notFoundMock).not.toHaveBeenCalled();
+  });
+
+  it('calls notFound when channelId is empty', async () => {
+    await expect(LiverPage(ctx(''))).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFoundMock).toHaveBeenCalled();
+    expect(fetchChannelInfoMock).not.toHaveBeenCalled();
+  });
+
+  it('calls notFound when fetchChannelInfo returns null', async () => {
+    fetchChannelInfoMock.mockResolvedValue(null);
+
+    await expect(LiverPage(ctx('missing'))).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(fetchChannelInfoMock).toHaveBeenCalledWith('missing');
+    expect(notFoundMock).toHaveBeenCalled();
+  });
+});

--- a/apps/nijiviewer/app/loading.test.tsx
+++ b/apps/nijiviewer/app/loading.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import Loading from './loading';
+
+describe('Loading', () => {
+  it('renders the spinner with a label', () => {
+    render(<Loading />);
+    expect(screen.getByLabelText('Loading...')).toBeInTheDocument();
+  });
+});

--- a/apps/nijiviewer/app/page.test.tsx
+++ b/apps/nijiviewer/app/page.test.tsx
@@ -1,15 +1,80 @@
-import { render, screen } from '@testing-library/react';
-import { expect, test } from 'vitest';
-import { HomeContent } from '@/components/home-content';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  mockPlaceholderVideo,
+  mockStreamVideo,
+} from '@/test/fixtures/holodex';
 
-test('heading 要素が想定通りに存在すること', () => {
-  render(<HomeContent />);
-  expect(
-    screen.getByRole('heading', { level: 1, name: /Discover/ }),
-  ).toBeDefined();
-  expect(
-    screen.getByText(
-      /Track and explore your favorite NijiSanji streamers in one place/,
-    ),
-  ).toBeDefined();
+const { fetchLiveVideosMock, homeContentMock } = vi.hoisted(() => ({
+  fetchLiveVideosMock: vi.fn(),
+  homeContentMock: vi.fn(() => null),
+}));
+
+vi.mock('@/lib/data', () => ({
+  fetchLiveVideos: fetchLiveVideosMock,
+}));
+
+vi.mock('@/components/home-content', () => ({
+  HomeContent: homeContentMock,
+}));
+
+import Home from './page';
+
+describe('Home page (app/page.tsx)', () => {
+  beforeEach(() => {
+    fetchLiveVideosMock.mockReset();
+    homeContentMock.mockClear();
+  });
+
+  it('fetches live videos for Nijisanji, keeps only top 3 live by viewers', async () => {
+    const live1 = mockStreamVideo({ id: 'v1', status: 'live', live_viewers: 100 });
+    const live2 = mockStreamVideo({ id: 'v2', status: 'live', live_viewers: 500 });
+    const live3 = mockStreamVideo({ id: 'v3', status: 'live', live_viewers: 300 });
+    const live4 = mockStreamVideo({ id: 'v4', status: 'live', live_viewers: 50 });
+    const upcoming = mockPlaceholderVideo({ id: 'u1' });
+
+    fetchLiveVideosMock.mockResolvedValue([upcoming, live1, live2, live3, live4]);
+
+    const tree = await Home();
+    const { render } = await import('@testing-library/react');
+    render(tree);
+
+    expect(fetchLiveVideosMock).toHaveBeenCalledWith('Nijisanji');
+    expect(homeContentMock).toHaveBeenCalled();
+    const [propsArg] = homeContentMock.mock.calls[0];
+    expect(propsArg.liveVideos).toEqual([live2, live3, live1]);
+  });
+
+  it('treats videos without live_viewers as 0 when sorting', async () => {
+    // Three videos, two missing live_viewers, force sort to compare both branches.
+    const live1 = mockStreamVideo({ id: 'v1', status: 'live' });
+    delete (live1 as { live_viewers?: number }).live_viewers;
+    const live2 = mockStreamVideo({ id: 'v2', status: 'live', live_viewers: 10 });
+    const live3 = mockStreamVideo({ id: 'v3', status: 'live' });
+    delete (live3 as { live_viewers?: number }).live_viewers;
+
+    fetchLiveVideosMock.mockResolvedValue([live1, live2, live3]);
+
+    const tree = await Home();
+    const { render } = await import('@testing-library/react');
+    render(tree);
+
+    const [propsArg] = homeContentMock.mock.calls[0];
+    // v2 (10) ranks first; the two zero-viewer entries follow.
+    expect(propsArg.liveVideos[0].id).toBe('v2');
+    expect(propsArg.liveVideos.map((v: { id: string }) => v.id).slice(1).sort()).toEqual([
+      'v1',
+      'v3',
+    ]);
+  });
+
+  it('passes an empty array when there are no live videos', async () => {
+    fetchLiveVideosMock.mockResolvedValue([mockPlaceholderVideo()]);
+
+    const tree = await Home();
+    const { render } = await import('@testing-library/react');
+    render(tree);
+
+    const [propsArg] = homeContentMock.mock.calls[0];
+    expect(propsArg.liveVideos).toEqual([]);
+  });
 });

--- a/apps/nijiviewer/app/providers.test.tsx
+++ b/apps/nijiviewer/app/providers.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Providers } from './providers';
+
+describe('Providers', () => {
+  it('renders children inside HeroUI / theme / auth providers', () => {
+    render(
+      <Providers themeProps={{ attribute: 'class', defaultTheme: 'dark' }}>
+        <span data-testid="child">hello</span>
+      </Providers>,
+    );
+
+    expect(screen.getByTestId('child')).toHaveTextContent('hello');
+  });
+
+  it('renders without theme props', () => {
+    render(
+      <Providers>
+        <span data-testid="child">no-theme</span>
+      </Providers>,
+    );
+
+    expect(screen.getByTestId('child')).toHaveTextContent('no-theme');
+  });
+});

--- a/apps/nijiviewer/app/settings/page.test.tsx
+++ b/apps/nijiviewer/app/settings/page.test.tsx
@@ -1,0 +1,282 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { HeroUIProvider } from '@heroui/react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import type { ReactNode } from 'react';
+import { mockUser } from '@/test/fixtures/auth';
+import { mockOrganization } from '@/test/fixtures/organizations';
+
+const { useAuthMock, usePreferencesMock } = vi.hoisted(() => ({
+  useAuthMock: vi.fn(),
+  usePreferencesMock: vi.fn(),
+}));
+
+vi.mock('@/context/auth-context', () => ({ useAuth: useAuthMock }));
+vi.mock('@/context/preferences-context', () => ({
+  usePreferences: usePreferencesMock,
+}));
+
+// Reorder.Group from motion/react requires drag/animate; we render a thin shim.
+vi.mock('motion/react', () => ({
+  Reorder: {
+    Group: ({
+      children,
+      onReorder,
+    }: {
+      children: ReactNode;
+      onReorder?: (next: string[]) => void;
+      values?: string[];
+    }) => (
+      <div data-testid="reorder-group" data-onreorder={typeof onReorder}>
+        {children}
+        {onReorder ? (
+          <button
+            type="button"
+            data-testid="reorder-trigger"
+            onClick={() => onReorder(['Hololive', 'Nijisanji'])}
+          >
+            reorder
+          </button>
+        ) : null}
+      </div>
+    ),
+    Item: ({ children }: { children: ReactNode }) => (
+      <div data-testid="reorder-item">{children}</div>
+    ),
+  },
+}));
+
+import SettingsPage from './page';
+
+const wrap = (ui: ReactNode) => <HeroUIProvider>{ui}</HeroUIProvider>;
+
+const setAuth = (overrides: Partial<ReturnType<typeof useAuthMock>> = {}) => {
+  useAuthMock.mockReturnValue({
+    user: null,
+    session: null,
+    isLoading: false,
+    signIn: vi.fn(),
+    signUp: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  });
+};
+
+type PrefValue = {
+  organizations: ReturnType<typeof mockOrganization>[];
+  favoriteOrgIds: string[];
+  isLoading: boolean;
+  toggleFavorite: ReturnType<typeof vi.fn>;
+  initializeFavorites: ReturnType<typeof vi.fn>;
+  updateOrder: ReturnType<typeof vi.fn>;
+};
+
+const setPrefs = (overrides: Partial<PrefValue> = {}): PrefValue => {
+  const value: PrefValue = {
+    organizations: [],
+    favoriteOrgIds: [],
+    isLoading: false,
+    toggleFavorite: vi.fn().mockResolvedValue(undefined),
+    initializeFavorites: vi.fn().mockResolvedValue(undefined),
+    updateOrder: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+  usePreferencesMock.mockReturnValue(value);
+  return value;
+};
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    useAuthMock.mockReset();
+    usePreferencesMock.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders only the spinner while auth is loading', () => {
+    setAuth({ isLoading: true });
+    setPrefs();
+
+    render(wrap(<SettingsPage />));
+    expect(screen.queryByText('Settings')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('You need to be signed in to manage settings.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders only the spinner while preferences are loading', () => {
+    setAuth();
+    setPrefs({ isLoading: true });
+
+    render(wrap(<SettingsPage />));
+    expect(screen.queryByText('Settings')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('You need to be signed in to manage settings.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the sign-in card when user is null', () => {
+    setAuth({ user: null });
+    setPrefs();
+
+    render(wrap(<SettingsPage />));
+
+    expect(
+      screen.getByText('You need to be signed in to manage settings.'),
+    ).toBeInTheDocument();
+  });
+
+  it('initializes favorites with every org id when the user has none yet', async () => {
+    const user = mockUser();
+    const orgA = mockOrganization({ id: 'Nijisanji', name: 'にじさんじ' });
+    const orgB = mockOrganization({ id: 'Hololive', name: 'ホロライブ' });
+    setAuth({ user });
+    const prefs = setPrefs({
+      organizations: [orgA, orgB],
+      favoriteOrgIds: [],
+    });
+
+    render(wrap(<SettingsPage />));
+
+    await waitFor(() => {
+      expect(prefs.initializeFavorites).toHaveBeenCalledWith([
+        'Nijisanji',
+        'Hololive',
+      ]);
+    });
+  });
+
+  it('does not call initializeFavorites when the user already has favorites', async () => {
+    const user = mockUser();
+    const orgA = mockOrganization({ id: 'Nijisanji', name: 'にじさんじ' });
+    setAuth({ user });
+    const prefs = setPrefs({
+      organizations: [orgA],
+      favoriteOrgIds: ['Nijisanji'],
+    });
+
+    render(wrap(<SettingsPage />));
+
+    await waitFor(() => {
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
+    expect(prefs.initializeFavorites).not.toHaveBeenCalled();
+  });
+
+  it('renders enabled and disabled organizations from preferences', () => {
+    const user = mockUser();
+    const orgA = mockOrganization({ id: 'Nijisanji', name: 'にじさんじ' });
+    const orgB = mockOrganization({ id: 'Hololive', name: 'ホロライブ' });
+    const orgC = mockOrganization({ id: 'VSpo', name: 'ぶいすぽ' });
+    setAuth({ user });
+    setPrefs({
+      organizations: [orgA, orgB, orgC],
+      favoriteOrgIds: ['Nijisanji', 'Hololive'],
+    });
+
+    render(wrap(<SettingsPage />));
+
+    expect(screen.getByText('Favorite Organizations')).toBeInTheDocument();
+    expect(screen.getByText('Available Organizations')).toBeInTheDocument();
+    expect(screen.getByText('にじさんじ')).toBeInTheDocument();
+    expect(screen.getByText('ホロライブ')).toBeInTheDocument();
+    expect(screen.getByText('ぶいすぽ')).toBeInTheDocument();
+  });
+
+  it('calls toggleFavorite when an inactive org is selected', async () => {
+    const user = mockUser();
+    const orgA = mockOrganization({ id: 'Nijisanji', name: 'にじさんじ' });
+    const orgB = mockOrganization({ id: 'Hololive', name: 'ホロライブ' });
+    setAuth({ user });
+    const prefs = setPrefs({
+      organizations: [orgA, orgB],
+      favoriteOrgIds: ['Nijisanji'],
+    });
+
+    render(wrap(<SettingsPage />));
+
+    // Find the disabled-section checkbox by its associated label text.
+    const disabledLabel = screen.getByText('ホロライブ');
+    const card = disabledLabel.closest('div')?.parentElement;
+    const checkbox = card?.querySelector('input[type="checkbox"]');
+    expect(checkbox).toBeTruthy();
+    if (!checkbox) throw new Error('checkbox not found');
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(prefs.toggleFavorite).toHaveBeenCalledWith('Hololive', true);
+    });
+  });
+
+  it('opens the constraint modal instead of removing the last favorite', async () => {
+    const user = mockUser();
+    const orgA = mockOrganization({ id: 'Nijisanji', name: 'にじさんじ' });
+    setAuth({ user });
+    const prefs = setPrefs({
+      organizations: [orgA],
+      favoriteOrgIds: ['Nijisanji'],
+    });
+
+    render(wrap(<SettingsPage />));
+
+    const enabledLabel = screen.getByText('にじさんじ');
+    const card = enabledLabel.closest('div')?.parentElement;
+    const checkbox = card?.querySelector('input[type="checkbox"]');
+    if (!checkbox) throw new Error('checkbox not found');
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(screen.getByText('Selection Required')).toBeInTheDocument();
+    });
+    expect(prefs.toggleFavorite).not.toHaveBeenCalled();
+
+    // Close the modal via OK button.
+    fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+  });
+
+  it('removes a favorite via toggleFavorite when more than one is selected', async () => {
+    const user = mockUser();
+    const orgA = mockOrganization({ id: 'Nijisanji', name: 'にじさんじ' });
+    const orgB = mockOrganization({ id: 'Hololive', name: 'ホロライブ' });
+    setAuth({ user });
+    const prefs = setPrefs({
+      organizations: [orgA, orgB],
+      favoriteOrgIds: ['Nijisanji', 'Hololive'],
+    });
+
+    render(wrap(<SettingsPage />));
+
+    const enabledLabel = screen.getByText('にじさんじ');
+    const card = enabledLabel.closest('div')?.parentElement;
+    const checkbox = card?.querySelector('input[type="checkbox"]');
+    if (!checkbox) throw new Error('checkbox not found');
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(prefs.toggleFavorite).toHaveBeenCalledWith('Nijisanji', false);
+    });
+  });
+
+  it('forwards reorder events to updateOrder', () => {
+    const user = mockUser();
+    const orgA = mockOrganization({ id: 'Nijisanji', name: 'にじさんじ' });
+    const orgB = mockOrganization({ id: 'Hololive', name: 'ホロライブ' });
+    setAuth({ user });
+    const prefs = setPrefs({
+      organizations: [orgA, orgB],
+      favoriteOrgIds: ['Nijisanji', 'Hololive'],
+    });
+
+    render(wrap(<SettingsPage />));
+
+    fireEvent.click(screen.getByTestId('reorder-trigger'));
+    expect(prefs.updateOrder).toHaveBeenCalledWith(['Hololive', 'Nijisanji']);
+  });
+});

--- a/apps/nijiviewer/test/helpers/auth-favorites-mocks.tsx
+++ b/apps/nijiviewer/test/helpers/auth-favorites-mocks.tsx
@@ -1,0 +1,51 @@
+import { HeroUIProvider } from '@heroui/react';
+import type { Session, User } from '@supabase/supabase-js';
+import type { ReactNode } from 'react';
+import { type Mock, vi } from 'vitest';
+import type { FavoriteLiver } from '@/lib/favorites';
+
+type AuthValue = {
+  user: User | null;
+  session: Session | null;
+  isLoading: boolean;
+  signIn: () => Promise<void>;
+  signUp: () => Promise<void>;
+  signOut: () => Promise<void>;
+};
+
+type FavoritesValue = {
+  favorites: FavoriteLiver[];
+  isLoading: boolean;
+  refetch: () => Promise<void>;
+};
+
+export const wrapWithHeroUI = (ui: ReactNode) => (
+  <HeroUIProvider>{ui}</HeroUIProvider>
+);
+
+export const stubAuth = (
+  mock: Mock,
+  overrides: Partial<AuthValue> = {},
+): void => {
+  mock.mockReturnValue({
+    user: null,
+    session: null,
+    isLoading: false,
+    signIn: vi.fn(),
+    signUp: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  });
+};
+
+export const stubFavorites = (
+  mock: Mock,
+  overrides: Partial<FavoritesValue> = {},
+): void => {
+  mock.mockReturnValue({
+    favorites: [],
+    isLoading: false,
+    refetch: vi.fn(),
+    ...overrides,
+  });
+};


### PR DESCRIPTION
## Summary

Brings every file under `apps/nijiviewer/app/` to **100%** statements / branches / functions / lines via Vitest unit tests. This is the third PR in the 5-step coverage plan.

### What's tested

- **Server Components**: `page.tsx`, `actions.ts`, `layout.tsx`, `providers.tsx`, `error.tsx`, `loading.tsx` — exercised by mocking `@/lib/data` and component imports, then rendering or invoking the resolved JSX.
- **Client pages** (`favorites/`, `favorites/edit/`, `settings/`) — loading, unauthenticated, empty, and populated branches via mocked auth and preferences contexts and mocked server actions.
- **Dynamic routes** (`live-videos/[organizationName]`, `liver/[channelId]`, `liver-search`) — valid input, validation failures, and `notFound()` paths.
- **Settings page** — also exercises the constraint modal and the `motion/react` `Reorder` integration via a thin shim.

### Coverage delta

| metric | before | after |
| --- | --- | --- |
| Statements | 55.0% | 64.43% |
| Branches | 43.13% | 51.09% |
| Functions | 50.82% | 60.98% |
| Lines | 53.71% | 64.09% |

`app/` itself is now 100% across all metrics; the remaining gap is the `components/` directory (PR 4) and threshold/CI wiring (PR 5).

## Test plan

- [x] `pnpm viewer build`
- [x] `pnpm viewer lint`
- [x] `pnpm viewer test` (unit + Storybook, 196/196 pass)
- [x] `pnpm viewer test:coverage` confirms `app/**` is 100%