### PR TITLE
ci: upgrade actions/cache to v5 for Node.js 24 runtime

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
       # Storybook テストは @storybook/addon-vitest 経由で Playwright のブラウザモードを使う
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}


### PR DESCRIPTION
## Summary

- `.github/workflows/pull_request.yml` の `actions/cache@v4` を `@v5` に更新
- v5 は Node.js 24 ランタイムで動作するため、GitHub Actions の deprecation 通知 (`Node.js 20 actions are deprecated`) を解消

## Why

直近の CI 実行で以下のアノテーションが継続的に出ていた:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

`actions/cache@v5` ([v5.0.0 リリースノート](https://github.com/actions/cache/releases/tag/v5.0.0)) で Node.js 24 に移行されており、Actions Runner 2.327.1 以上が必要。GitHub-hosted runner (`ubuntu-latest`) は既に該当要件を満たす。

その他の actions (`actions/checkout@v6`, `actions/setup-node@v6`, `actions/upload-artifact@v7`, `pnpm/action-setup@v6`) は既に最新メジャー。

## Test plan

- [ ] Node.js CI ワークフローが green
- [ ] Playwright ブラウザのキャッシュヒット / ミスが正常に動作
- [ ] Node.js 20 deprecation アノテーションが消えていることを CI ログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)