### PR TITLE
[codex] Supabase Data APIの権限を明示化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,12 @@ pnpm test:e2e --grep "テスト名"
 
 `lib/data.ts` 内の Holodex API 呼び出しはすべて `neverthrow` の `Result` 型を返す。呼び出し元は `Ok`/`Err` を明示的にハンドルすること。
 
+### Supabase マイグレーション
+
+- `public` スキーマにテーブル、シーケンス、関数を追加するときは、Data API で必要な操作だけを `anon` / `authenticated` / `service_role` に明示的に `GRANT` すること。デフォルト権限に依存しない。
+- Data API に公開するテーブルは RLS を有効化し、`GRANT` と対応するポリシーを同じマイグレーションに含めること。
+- ID 採番でシーケンスを使用する場合は、対象ロールへの `USAGE` / `SELECT` も明示すること。
+
 ### 画像ルーティング
 
 外部画像はすべて `lib/image-utils.ts` の `getImageUrl()` → `/api/image-proxy` を経由する（data URI・相対パスはそのまま通過）。

--- a/apps/nijiviewer/db/migrations/20260630_add_explicit_data_api_grants.sql
+++ b/apps/nijiviewer/db/migrations/20260630_add_explicit_data_api_grants.sql
@@ -1,0 +1,44 @@
+-- Remove legacy automatic grants before exposing only the operations used
+-- through supabase-js. RLS policies continue to determine which rows each
+-- user can access.
+revoke all privileges
+  on table public.organizations,
+           public.favorite_livers,
+           public.user_favorite_organizations,
+           public.liver_search_history
+  from anon, authenticated;
+
+grant select
+  on table public.organizations
+  to anon, authenticated;
+
+grant select, insert, delete
+  on table public.favorite_livers
+  to authenticated;
+
+grant select, insert, update, delete
+  on table public.user_favorite_organizations
+  to authenticated;
+
+grant select, insert, delete
+  on table public.liver_search_history
+  to authenticated;
+
+-- Inserts into tables with generated numeric IDs require their sequences.
+revoke all privileges
+  on sequence public.favorite_livers_id_seq,
+              public.liver_search_history_id_seq
+  from anon, authenticated;
+
+grant usage, select
+  on sequence public.favorite_livers_id_seq,
+              public.liver_search_history_id_seq
+  to authenticated;
+
+-- The application supports deleting a user's own search history. The original
+-- table migration did not include the corresponding RLS policy.
+create policy "Users can delete own search history"
+  on public.liver_search_history
+  for delete
+  to authenticated
+  using (auth.uid() = creator_id);

--- a/apps/sync-board/lib/loro-sync.test.ts
+++ b/apps/sync-board/lib/loro-sync.test.ts
@@ -52,11 +52,11 @@ const makeEdge = (id: string, source: string, target: string): Edge => ({
   target,
 });
 
-async function waitForWebSocket(): Promise<MockWebSocket> {
-  const before = MockWebSocket.instances.length;
-  for (let i = 0; i < 100; i += 1) {
-    if (MockWebSocket.instances.length > before) {
-      const ws = MockWebSocket.instances[before];
+async function waitForWebSocket(index: number): Promise<MockWebSocket> {
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    if (MockWebSocket.instances.length > index) {
+      const ws = MockWebSocket.instances[index];
       // Handlers are attached after the dynamic `await import('loro-crdt')`
       // resolves; wait one extra microtask so onmessage is wired up before we
       // emit anything.
@@ -65,7 +65,7 @@ async function waitForWebSocket(): Promise<MockWebSocket> {
         return ws;
       }
     }
-    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 10));
   }
   throw new Error('Timed out waiting for WebSocket constructor');
 }
@@ -75,8 +75,9 @@ async function initialize(
   initialEdges: Edge[],
   initialSnapshot: Uint8Array = new Uint8Array(0),
 ): Promise<{ synced: SyncedDoc; ws: MockWebSocket }> {
+  const wsIndex = MockWebSocket.instances.length;
   const promise = createSyncedDoc('ws://test', initialNodes, initialEdges);
-  const ws = await waitForWebSocket();
+  const ws = await waitForWebSocket(wsIndex);
   ws.emit(initialSnapshot);
   const synced = await promise;
   return { synced, ws };
@@ -110,8 +111,9 @@ describe('createSyncedDoc', () => {
   });
 
   it('skips populating the doc when an existing snapshot is received', async () => {
+    const seedWsIndex = MockWebSocket.instances.length;
     const seedPromise = createSyncedDoc('ws://seed', [makeNode('seed')], []);
-    const seedWs = await waitForWebSocket();
+    const seedWs = await waitForWebSocket(seedWsIndex);
     seedWs.emit(new Uint8Array(0));
     const seedDoc = await seedPromise;
     const snapshot = seedDoc.exportDocument();
@@ -286,16 +288,18 @@ describe('createSyncedDoc', () => {
   });
 
   it('rejects when the WebSocket closes before initialization', async () => {
+    const wsIndex = MockWebSocket.instances.length;
     const promise = createSyncedDoc('ws://failing', [], []);
-    const ws = await waitForWebSocket();
+    const ws = await waitForWebSocket(wsIndex);
     ws.onclose?.({} as Event);
 
     await expect(promise).rejects.toThrow(/closed before init/);
   });
 
   it('rejects when the WebSocket errors before initialization', async () => {
+    const wsIndex = MockWebSocket.instances.length;
     const promise = createSyncedDoc('ws://failing', [], []);
-    const ws = await waitForWebSocket();
+    const ws = await waitForWebSocket(wsIndex);
     const err = new Event('error');
     ws.onerror?.(err);
 


### PR DESCRIPTION
## 概要

SupabaseのData APIに関するデフォルト権限変更へ対応します。既存の`public`テーブルについて、アプリが実際に使用する操作だけを`anon` / `authenticated`へ明示的に付与するマイグレーションを追加しました。

## 変更内容

- 旧デフォルトで自動付与されたクライアントロールのテーブル権限を解除
- `organizations`は`anon` / `authenticated`へ参照権限のみ付与
- ユーザー固有データ3テーブルは`authenticated`へ必要なCRUD権限のみ付与
- ID採番用シーケンスへ`USAGE` / `SELECT`を明示的に付与
- `liver_search_history`に不足していた、自分の検索履歴を削除するRLSポリシーを追加
- 今後のSupabaseマイグレーションで、RLS・ポリシー・明示的な`GRANT`をセットで管理する規約を`AGENTS.md`へ追加
- sync-boardのWebSocketテストで、生成対象のインスタンスを呼び出し前に特定し、CIの低速な初回モジュール読み込みを許容する待機処理へ変更

## 背景・原因

Supabaseでは2026年10月30日以降、既存プロジェクトでも`public`スキーマに新規作成したテーブルがData APIへ自動公開されなくなります。既存マイグレーションは従来のデフォルト権限に依存しており、新しいデフォルト設定でDBを再構築すると`supabase-js`から`42501 permission denied`になる可能性がありました。

また、既存環境には従来の広い自動権限が残るため、今回のマイグレーションでクライアントロールの権限を最小権限へ統一します。RLSは引き続き行単位のアクセス制御として機能します。

初回CIでは、sync-boardのテストが`loro-crdt`の動的読み込み完了前に短いポーリングを打ち切り、WebSocket生成待ちで失敗しました。これはSupabase変更とは無関係な既存のタイミング依存であり、待機対象とタイムアウトを明示して安定化しました。

## 影響

- 現在アプリが利用している参照・登録・更新・削除操作は維持されます。
- アプリが使用していないData API操作は`anon` / `authenticated`から実行できなくなります。
- マイグレーション適用後、検索履歴の削除がRLS上も許可されます。
- sync-boardのプロダクションコードに変更はありません。

## 検証

- `pnpm build`
- `pnpm lint`
- `pnpm test`（unit + Storybook browser tests）
- sync-board対象テスト: 2回連続で16件成功
- GitHub Actions: [Node.js CI run 28411742831](https://github.com/MakotoUwaya/nijiviewer/actions/runs/28411742831) 成功
